### PR TITLE
Trying to name deployment module properly

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,4 +5,4 @@ quarkusPlatformArtifactId=quarkus-universe-bom
 quarkusPlatformVersion=2.16.6.Final
 
 quarkusExtensionName=quarkus-extension-gradle-deployment-module-bug
-quarkusExtensionDeploymentPrefix=a-
+quarkusExtensionDeploymentPrefix=

--- a/runtime/build.gradle
+++ b/runtime/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 quarkusExtension {
-    deploymentModule = "${quarkusExtensionDeploymentPrefix}${quarkusExtensionName}-deployment"
+    deploymentModule = "${quarkusExtensionDeploymentPrefix}${quarkusExtensionName}"
 }
 
 dependencies {


### PR DESCRIPTION
Removed "-deployment" from quarkusExtension.deploymentModule
Removed "a-" prefix for deployment module name.